### PR TITLE
Update volume if only amount is deducted from the order

### DIFF
--- a/src/OrderTree.java
+++ b/src/OrderTree.java
@@ -81,4 +81,8 @@ public class OrderTree {
 
         return builder.toString();
     }
+
+    public void updateVolume(double tradedQuantity) {
+        volume -= tradedQuantity;
+    }
 }


### PR DESCRIPTION
If order is matched with more than one then volume is not being update because in case delete volume is already decreased in the order but not from volume.